### PR TITLE
Fix: Use user ID for owner verification

### DIFF
--- a/src/plex/accounts.ts
+++ b/src/plex/accounts.ts
@@ -105,9 +105,8 @@ export class PlexServerAccountsStore {
 					throw error;
 				}
 				// ensure the account info matches the owner info
-				if (plexUserInfo.email != myPlexAccountPage.MyPlex.username
-				   && plexUserInfo.username != myPlexAccountPage.MyPlex.username) {
-					console.error(`User info ${plexUserInfo.email ?? plexUserInfo.username} doesnt match plex server owner ${myPlexAccountPage.MyPlex.username}`);
+				if (plexUserInfo.id != myPlexAccountPage.MyPlex.id) {
+					console.error(`User id ${plexUserInfo.id} doesnt match plex server owner id ${myPlexAccountPage.MyPlex.id}`);
 					return null;
 				}
 				// add user info for owner

--- a/src/plex/types/MyPlex.ts
+++ b/src/plex/types/MyPlex.ts
@@ -1,8 +1,10 @@
 
 export type PlexMyPlexAccount = {
+	id: number;
 	authToken: string;
 	username: string; // name@example.com
 	signInState: string;
+	mappingState?: string;
 	publicAddress: string;
 	publicPort: number;
 	privateAddress: string;


### PR DESCRIPTION
The previous implementation used username/email comparison to verify the server owner, which is unreliable because a user's Plex username can differ from their email address. This could lead to authentication failures.

This commit changes the owner verification logic to use the user ID, which is a more reliable method. The user ID is retrieved from the `/myplex/account` endpoint and compared with the user ID from the Plex.tv API. This ensures that the owner is correctly identified, even if their username and email are different.

The `PlexMyPlexAccount` type has been updated to include the `id` property.