### PR TITLE
Fix: Use correct user ID for owner verification

### DIFF
--- a/src/plex/accounts.ts
+++ b/src/plex/accounts.ts
@@ -105,8 +105,9 @@ export class PlexServerAccountsStore {
 					throw error;
 				}
 				// ensure the account info matches the owner info
-				if (plexUserInfo.id != myPlexAccountPage.MyPlex.id) {
-					console.error(`User id ${plexUserInfo.id} doesnt match plex server owner id ${myPlexAccountPage.MyPlex.id}`);
+				const plexServerOwnerId = Number.parseInt(myPlexAccountPage.MyPlex.$.id);
+				if (!plexServerOwnerId || plexUserInfo.id != plexServerOwnerId) {
+					console.error(`User id ${plexUserInfo.id} doesnt match plex server owner id ${plexServerOwnerId}`);
 					return null;
 				}
 				// add user info for owner

--- a/src/plex/types/MyPlex.ts
+++ b/src/plex/types/MyPlex.ts
@@ -1,6 +1,19 @@
 
 export type PlexMyPlexAccount = {
-	id: number;
+	$: {
+		id: string;
+		username: string; // name@example.com
+		email: string; // name@example.com
+		mappingState?: string;
+		signInState: string;
+		publicAddress: string;
+		publicPort: string;
+		privateAddress: string;
+		privatePort: string;
+		subscriptionFeatures?: string;
+		subscriptionActive: string;
+		subscriptionState: string;
+	};
 	authToken: string;
 	username: string; // name@example.com
 	signInState: string;


### PR DESCRIPTION
The previous implementation was using an incorrect property to get the user ID from the `/myplex/account` endpoint. This was causing the owner verification to fail.

This commit updates the code to use the correct property, `myPlexAccountPage.MyPlex.$.id`, to retrieve the user ID. The `PlexMyPlexAccount` type has also been updated to reflect the correct structure of the XML response.

This ensures that the owner is correctly identified, even if their username and email are different, and fixes the "401 Not Authorized" error.